### PR TITLE
"provides" takes a hashref

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,7 +3,7 @@
     "version"     : "*",
     "description" : "Simple benchmark graphing script",
     "depends"     : ["SVG", "SVG::Plot"],
-    "provides"    : [ ],
+    "provides"    : { },
     "source-type"   : "git",
     "source-url"    : "git://github.com/colomon/Benchmark-Plot.git"
 }


### PR DESCRIPTION
Based on the spec, `provides` takes a hashref not an arrayref: http://design.perl6.org/S22.html#line_219

Also, based on [this conversation](http://irclog.perlgeek.de/perl6/2015-10-10#i_11353763), script-only dists don't need `provides` at all, but I believe removing it completely will mark the dist as not panda-S11-compatible, hence why I still left it in in the PR.
